### PR TITLE
fix(stream): wire LIVE/DEMO toggle to actually switch data sources

### DIFF
--- a/src/data/sampleAlerts.ts
+++ b/src/data/sampleAlerts.ts
@@ -1,26 +1,75 @@
 import type { Alert } from "../types/Alert";
 
+// Real, geolocatable public IPs spread across continents so the demo map
+// renders multiple arcs. Avoid RFC 5737 test ranges — they don't resolve.
+const now = Date.now();
+
 export const sampleAlerts: Alert[] = [
   {
     id: "demo-1",
-    ts: new Date().toISOString(),
+    ts: new Date(now).toISOString(),
+    source: "wazuh",
+    severity: "critical",
+    ruleId: "2010935",
+    ruleDesc: "ET EXPLOIT Possible CVE attempt",
+    agent: { id: "001", name: "debian-vm" },
+    srcIp: "185.220.101.1", // Tor exit, DE
+    dstIp: "10.0.0.4",
+    techniqueIds: ["T1190"],
+  },
+  {
+    id: "demo-2",
+    ts: new Date(now - 60_000).toISOString(),
     source: "wazuh",
     severity: "high",
     ruleId: "5710",
     ruleDesc: "Multiple authentication failures",
     agent: { id: "001", name: "debian-vm" },
-    srcIp: "203.0.113.42",
+    srcIp: "45.155.205.233", // RU
     techniqueIds: ["T1110"],
   },
   {
-    id: "demo-2",
-    ts: new Date(Date.now() - 60_000).toISOString(),
+    id: "demo-3",
+    ts: new Date(now - 120_000).toISOString(),
     source: "suricata",
-    severity: "critical",
-    ruleId: "2010935",
-    ruleDesc: "ET EXPLOIT Possible CVE attempt",
-    srcIp: "198.51.100.7",
+    severity: "high",
+    ruleId: "2024897",
+    ruleDesc: "ET SCAN Suspicious inbound to mySQL port 3306",
+    srcIp: "121.40.95.50", // CN
     dstIp: "10.0.0.4",
-    techniqueIds: ["T1190"],
+    techniqueIds: ["T1046"],
+  },
+  {
+    id: "demo-4",
+    ts: new Date(now - 200_000).toISOString(),
+    source: "wazuh",
+    severity: "medium",
+    ruleId: "31151",
+    ruleDesc: "Multiple web server 400 error codes",
+    agent: { id: "002", name: "nginx-edge" },
+    srcIp: "104.244.72.7", // US
+    techniqueIds: ["T1595"],
+  },
+  {
+    id: "demo-5",
+    ts: new Date(now - 300_000).toISOString(),
+    source: "suricata",
+    severity: "low",
+    ruleId: "2013030",
+    ruleDesc: "ET POLICY curl User-Agent Outbound",
+    srcIp: "102.88.137.213", // NG
+    dstIp: "10.0.0.4",
+    techniqueIds: ["T1071"],
+  },
+  {
+    id: "demo-6",
+    ts: new Date(now - 420_000).toISOString(),
+    source: "wazuh",
+    severity: "high",
+    ruleId: "5715",
+    ruleDesc: "SSH brute force attempt",
+    agent: { id: "001", name: "debian-vm" },
+    srcIp: "203.205.219.1", // VN
+    techniqueIds: ["T1110.001"],
   },
 ];

--- a/src/hooks/useStream.ts
+++ b/src/hooks/useStream.ts
@@ -1,12 +1,9 @@
 import { useEffect } from "react";
 import { useStreamStore } from "../store/streamStore";
+import { useUiStore } from "../store/useUiStore";
 import { sampleAlerts } from "../data/sampleAlerts";
 import type { Alert, Severity } from "../types/Alert";
 import type { GeoEvent } from "../types/GeoEvent";
-
-const isDemo = () =>
-  typeof window !== "undefined" &&
-  new URLSearchParams(window.location.search).get("demo") === "1";
 
 function levelToSeverity(level: number): Severity {
   if (level >= 15) return "critical";
@@ -32,7 +29,8 @@ function normalizeAlert(raw: any): Alert {
   };
 }
 
-// Module-level cache so IPs already resolved don't trigger a second BFF call
+// Module-level cache so IPs already resolved don't trigger a second BFF call.
+// Cleared on demo/live toggle so the map redraws from scratch.
 const resolvedIps = new Set<string>();
 
 async function resolveGeoIps(
@@ -84,11 +82,18 @@ export const useStream = () => {
   const setStatus = useStreamStore((s) => s.setStatus);
   const pushAlert = useStreamStore((s) => s.pushAlert);
   const pushGeoEvent = useStreamStore((s) => s.pushGeoEvent);
+  const clear = useStreamStore((s) => s.clear);
+  const demoMode = useUiStore((s) => s.demoMode);
 
   useEffect(() => {
-    if (isDemo()) {
+    // Reset accumulated state so a mode switch redraws from scratch.
+    clear();
+    resolvedIps.clear();
+
+    if (demoMode) {
       setStatus("open");
       sampleAlerts.forEach(pushAlert);
+      resolveGeoIps(sampleAlerts, pushGeoEvent);
       return;
     }
 
@@ -117,7 +122,7 @@ export const useStream = () => {
       es?.close();
       setStatus("closed");
     };
-  }, [pushAlert, pushGeoEvent, setStatus]);
+  }, [demoMode, clear, pushAlert, pushGeoEvent, setStatus]);
 
   return { status };
 };

--- a/src/store/useUiStore.ts
+++ b/src/store/useUiStore.ts
@@ -20,7 +20,7 @@ type UiState = {
 }
 
 export const useUiStore = create<UiState>((set) => ({
-  demoMode: true,
+  demoMode: false,
   toggleDemo: () => set((s) => ({ demoMode: !s.demoMode })),
   activeView: 'timeline',
   setView: (v) => set({ activeView: v }),


### PR DESCRIPTION
- useStream now subscribes to useUiStore.demoMode and rebuilds on toggle
- clears geoEvents + resolvedIps cache so the map redraws from scratch
- default demoMode flipped to false so app boots into live mode
- replaced RFC 5737 demo IPs with real geolocatable ones across 6 regions

## What this PR does

<!-- One or two sentences. -->

## Scope

- [ ] Feature
- [x] Fix
- [ ] Refactor / chore
- [ ] Docs

## Owner

<!-- Taha or Ismail -->

## Checklist

- [ ] `npm run lint` passes (tsc strict, 0 errors)
- [ ] `npm run test` passes
- [ ] `npm run build` succeeds
- [ ] Demo Mode still works (no live infra needed)
- [ ] No secrets committed (`.env`, tokens, IPs)

## Screenshots (if UI)

<!-- Drag images here. -->
